### PR TITLE
Migrate project images to gatsby-plugin-sanity-image

### DIFF
--- a/src/components/pages/project/BeforeAfterSlider/index.js
+++ b/src/components/pages/project/BeforeAfterSlider/index.js
@@ -72,8 +72,8 @@ const StyledBlockText = styled(StyledText)`
 `;
 
 const BeforeAfterSlider = ({ imageBefore, imageAfter, text }) => {
-  const beforeSrc = imageBefore.asset.gatsbyImageData.images.fallback.src;
-  const afterSrc = imageAfter.asset.gatsbyImageData.images.fallback.src;
+  const beforeSrc = `${imageBefore.asset.url}?w=1200&auto=format`;
+  const afterSrc = `${imageAfter.asset.url}?w=1200&auto=format`;
   return (
     <StyledBlockContainer>
       <StyledContentBlock>

--- a/src/components/pages/project/ImageTextSection/index.js
+++ b/src/components/pages/project/ImageTextSection/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import SanityImage from "gatsby-plugin-sanity-image";
 import styled from "styled-components";
 import Grid from "components/global/Grid";
 import PageContainer from "components/global/PageContainer";
@@ -25,10 +25,12 @@ const StyledImageTextSection = styled(Grid)`
   }
 `;
 
-const StyledSectionImage = styled(GatsbyImage)`
+const StyledSectionImage = styled(SanityImage)`
   max-height: calc(100vh - 60px);
   grid-column: span 4;
   margin-bottom: 30px;
+  width: 100%;
+  object-fit: cover;
   @media ${(props) => props.theme.minWidth.md} {
     max-height: calc(100vh - 80px);
     grid-column: ${({ islandscape }) =>
@@ -46,14 +48,14 @@ const StyledSectionText = styled(StyledText)`
 
 const ImageTextSection = ({ image, text, orientation }) => {
   if (image) {
-    const sectionImage = getImage(image.asset);
     const isLandscape = orientation === "landscape";
     if (text) {
       return (
         <StyledSectionContainer key={text}>
           <StyledImageTextSection>
             <StyledSectionImage
-              image={sectionImage}
+              {...image}
+              width={1200}
               islandscape={isLandscape.toString()}
               alt={`Section image ${text}`}
             />
@@ -66,7 +68,8 @@ const ImageTextSection = ({ image, text, orientation }) => {
         <StyledSectionContainer key={text}>
           <StyledImageTextSection>
             <StyledSectionImage
-              image={sectionImage}
+              {...image}
+              width={1200}
               alt={`Section image ${text}`}
             />
           </StyledImageTextSection>

--- a/src/components/pages/project/ProjectCarousel/index.js
+++ b/src/components/pages/project/ProjectCarousel/index.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from "react";
 import styled from "styled-components";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import SanityImage from "gatsby-plugin-sanity-image";
 import Button from "components/global/Button";
 import Text from "components/global/Text";
 import Slider from "react-slick";
@@ -79,14 +79,16 @@ const ProjectCarousel = ({ images }) => {
   return (
     <StyledBlockContainer>
       <StyledSlider {...settings} ref={sliderRef}>
-        {images.map(({ image }) => {
-          const getGatsbyImage = getImage(image.asset);
+        {images.map(({ image }, index) => {
           return (
-            <div key={image.asset} className="carousel-item">
-              <GatsbyImage
+            <div key={index} className="carousel-item">
+              <SanityImage
+                {...image}
+                width={800}
+                height={600}
                 className="carousel-image"
-                image={getGatsbyImage}
                 alt="Image à faire défiler"
+                style={{ objectFit: "cover", width: "100%", height: "100%" }}
               />
             </div>
           );

--- a/src/templates/Project/index.js
+++ b/src/templates/Project/index.js
@@ -242,6 +242,9 @@ export const query = graphql`
       description
       image {
         ...ImageWithPreview
+        asset {
+          url
+        }
       }
       slug {
         current
@@ -261,9 +264,15 @@ export const query = graphql`
       beforeAfterImages {
         imageAfter {
           ...ImageWithPreview
+          asset {
+            url
+          }
         }
         imageBefore {
           ...ImageWithPreview
+          asset {
+            url
+          }
         }
         text
       }

--- a/src/templates/Project/index.js
+++ b/src/templates/Project/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { graphql } from "gatsby";
 import Layout from "components/Layout";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
+import SanityImage from "gatsby-plugin-sanity-image";
 import styled from "styled-components";
 import Grid from "components/global/Grid";
 import PageContainer from "components/global/PageContainer";
@@ -26,11 +26,12 @@ const StyledHeader = styled(Grid)`
   }
 `;
 
-const StyledHeroImage = styled(GatsbyImage)`
+const StyledHeroImage = styled(SanityImage)`
   grid-row: 1 / 2;
   grid-column: span 4;
   height: 100%;
   width: 100%;
+  object-fit: cover;
   @media ${(props) => props.theme.minWidth.md} {
     grid-column: span 7;
   }
@@ -240,9 +241,7 @@ export const query = graphql`
       architect
       description
       image {
-        asset {
-          gatsbyImageData
-        }
+        ...ImageWithPreview
       }
       slug {
         current
@@ -254,32 +253,24 @@ export const query = graphql`
       }
       ImageTextSections {
         image {
-          asset {
-            gatsbyImageData
-          }
+          ...ImageWithPreview
         }
         text
         orientation
       }
       beforeAfterImages {
         imageAfter {
-          asset {
-            gatsbyImageData
-          }
+          ...ImageWithPreview
         }
         imageBefore {
-          asset {
-            gatsbyImageData
-          }
+          ...ImageWithPreview
         }
         text
       }
       isFeaturedProject
       projectCarousel {
         image {
-          asset {
-            gatsbyImageData(height: 600)
-          }
+          ...ImageWithPreview
         }
       }
     }
@@ -304,7 +295,6 @@ const Project = ({ data }) => {
     projectCarousel,
     isFeaturedProject,
   } = data.sanityProject;
-  const heroImage = getImage(image.asset);
   const projectYear = new Date(year).getFullYear();
   const heroVideo = video && video.asset.url;
   const [isMuted, setIsMuted] = useState(true);
@@ -314,7 +304,7 @@ const Project = ({ data }) => {
       <Seo
         pageTitle={name}
         articleDescription={description}
-        imageUrl={image.asset.gatsbyImageData.images.fallback.src}
+        imageUrl={image.asset.url}
       />
       <Layout>
         <div className="pageAnimation">
@@ -335,7 +325,7 @@ const Project = ({ data }) => {
                 </StyledSoundButton>
               </>
             ) : (
-              <StyledHeroImage image={heroImage} alt={name} />
+              <StyledHeroImage {...image} alt={name} width={1920} />
             )}
             <StyledVerticalLine />
             <StyledCategory type="label">{category}</StyledCategory>


### PR DESCRIPTION
## Summary
- Replace `gatsby-plugin-image` (`GatsbyImage`/`getImage`) with `gatsby-plugin-sanity-image` (`SanityImage`) across project page components (BeforeAfterSlider, ImageTextSection, ProjectCarousel, Project template)
- Use `...ImageWithPreview` fragment in GraphQL queries to reduce Sanity CDN bandwidth
- Fix missing `asset.url` in GraphQL queries for before/after slider and SEO og:image

## Test plan
- [x] Verify before/after slider images load correctly
- [x] Verify hero images render on project pages
- [x] Check project carousel displays images properly
- [x] Confirm SEO og:image URL resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)